### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn start"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # ECommerceApp
+[![Run on Repl.it](https://repl.it/badge/github/heet-vakharia/ECommerceApp)](https://repl.it/github/heet-vakharia/ECommerceApp)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).